### PR TITLE
[BSU-0027] Changed Statement to function

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -100,7 +100,7 @@ identifier_name:
 nesting:
   type_level:
     warning: 2
-  statement_level:
+  function_level:
     warning: 3
 
 switch_case_alignment:


### PR DESCRIPTION
To silence 'statement_level' has been renamed to 'function_level' and will be completely removed in a future release. warning